### PR TITLE
Change X-GNOME-SingleWindow key to SingleMainWindow

### DIFF
--- a/lib/xdg/telegramdesktop.desktop
+++ b/lib/xdg/telegramdesktop.desktop
@@ -13,7 +13,7 @@ MimeType=x-scheme-handler/tg;
 Keywords=tg;chat;im;messaging;messenger;sms;tdesktop;
 Actions=Quit;
 X-GNOME-UsesNotifications=true
-X-GNOME-SingleWindow=true
+SingleMainWindow=true
 
 [Desktop Action Quit]
 Exec=telegram-desktop -quit


### PR DESCRIPTION
X-GNOME-SingleWindow was upstreamed to be an XDG spec with the name "SingleMainWindow" in https://gitlab.freedesktop.org/xdg/xdg-specs/-/merge_requests/53