### PR TITLE
Fix Global Search function

### DIFF
--- a/Telegram/SourceFiles/core/application.cpp
+++ b/Telegram/SourceFiles/core/application.cpp
@@ -1292,12 +1292,6 @@ void Application::startShortcuts() {
 		request->check(Command::Minimize) && request->handle([=] {
 			return minimizeActiveWindow();
 		});
-		request->check(Command::GlobalSearch) && request->handle([=] {
-			auto window = activeWindow();
-			auto mainWidget = window->widget()->sessionContent();
-			mainWidget->dialogsFocus();
-			return true;
-		});
 		request->check(Command::Close) && request->handle([=] {
 			return closeActiveWindow();
 		});

--- a/Telegram/SourceFiles/dialogs/dialogs_widget.h
+++ b/Telegram/SourceFiles/dialogs/dialogs_widget.h
@@ -174,6 +174,8 @@ private:
 	void startScrollUpButtonAnimation(bool shown);
 	void updateScrollUpPosition();
 
+	void setupShortcuts(not_null<Window::SessionController *> controller);
+
 	MTP::Sender _api;
 
 	bool _dragInScroll = false;

--- a/Telegram/SourceFiles/mainwidget.cpp
+++ b/Telegram/SourceFiles/mainwidget.cpp
@@ -2685,10 +2685,6 @@ bool MainWidget::isThreeColumn() const {
 	return _controller->adaptive().isThreeColumn();
 }
 
-void MainWidget::dialogsFocus() {
-	return _dialogs->setInnerFocus();
-}
-
 namespace App {
 
 MainWidget *main() {

--- a/Telegram/SourceFiles/mainwidget.h
+++ b/Telegram/SourceFiles/mainwidget.h
@@ -235,7 +235,6 @@ public:
 		const SectionShow &params) const;
 
 	void dialogsCancelled();
-	void dialogsFocus();
 
 protected:
 	void paintEvent(QPaintEvent *e) override;


### PR DESCRIPTION
Set shortcuts in application is too wide, when user is editing group info or other message box, shortcuts is still work.

### **Fix**
Move this shortcut to the dialog widget, so that user won't trigger this shortcut when focus on the other message box.
Exit archive folder when user is in archive folder, that will automatically focus to search box.
When application is in one column mode, clear the section stack and leave the chat.
Set focus on search box when not in one column mode.