### PR TITLE
README: Update text in Localization

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ Create a Pull Request: [Localization Repo](https://github.com/TDesktop-x64/Local
 
 You can find a language ID on Telegram's log.txt
 
-For example: `[2020.07.10 07:32:16] Current Language ID: en, Base ID: `
+For example: `[2022.04.23 10:37:45] Current Language pack ID: de, Base ID: `
 
-Then your language translation filename is `en.json` or something like that.
+Then your language translation filename is `de.json` or something like that.
 
 ***Note: Ignore base ID(base ID translation - Work in progress)***
 


### PR DESCRIPTION
I copied my text 1:1, if that doesn't fit you can change my "de" back to "en".

Why the change?
The text has changed in the 2 years.
Better for the search function of the text editor.

![Screenshot 2022-04-23 113959](https://user-images.githubusercontent.com/40471551/164889685-0997924c-100c-4624-94ee-c65ee9350568.png)

