### PR TITLE
Add a "large message radius" toggle

### DIFF
--- a/Telegram/SourceFiles/ui/chat/chat.style
+++ b/Telegram/SourceFiles/ui/chat/chat.style
@@ -703,7 +703,7 @@ historyInfoToast: Toast(defaultToast) {
 	iconPosition: point(13px, 13px);
 }
 
-bubbleRadiusSmall: 6px;
+bubbleRadiusSmall: 16px;
 bubbleRadiusLarge: 6px;
 
 historyPhotoLeft: 14px;

--- a/Telegram/SourceFiles/ui/chat/chat_style_radius.cpp
+++ b/Telegram/SourceFiles/ui/chat/chat_style_radius.cpp
@@ -19,8 +19,8 @@ namespace {
 
 base::options::toggle UseSmallMsgBubbleRadius({
 	.id = kOptionUseSmallMsgBubbleRadius,
-	.name = "Use small message bubble radius",
-	.description = "Makes most message bubbles square-ish.",
+	.name = "Use large message bubble radius",
+	.description = "Makes most message bubbles large-ish.",
 	.restartRequired = true,
 });
 

--- a/Telegram/SourceFiles/ui/chat/chat_style_radius.cpp
+++ b/Telegram/SourceFiles/ui/chat/chat_style_radius.cpp
@@ -20,7 +20,7 @@ namespace {
 base::options::toggle UseSmallMsgBubbleRadius({
 	.id = kOptionUseSmallMsgBubbleRadius,
 	.name = "Use large message bubble radius",
-	.description = "Makes most message bubbles large-ish.",
+	.description = "Makes most message bubbles rounded.",
 	.restartRequired = true,
 });
 


### PR DESCRIPTION
Closes #124.

64Gram's actual behavior is:

`bubbleRadiusSmall: 6px;`
`bubbleRadiusLarge: 6px;`

Taking in consideration 64Gram uses `bubbleRadiusLarge` as default, I kept that to `6px`, which is what you prefer as the developer. However, I changed `bubbleRadiusSmall` to `16px`, because if you manually go to Settings > Advanced > Experimental Settings and turn on the toggle, 64Gram uses `bubbleRadiusSmall`, so people who like rounded bubble radius can be happy too.

This is a solution designed and carried out quickly. I know that from a development point of view it is a disaster to change it just like that, but taking into account that the developer of 64Gram makes his client as he likes and that he will not want to waste his time for free in features he does not want, I have contributed this grain of sand.