### PR TITLE
Do not open stories

### DIFF
--- a/Telegram/Resources/langs/lang.strings
+++ b/Telegram/Resources/langs/lang.strings
@@ -4483,6 +4483,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 "lng_settings_show_seconds" = "Time with seconds";
 "lng_settings_hide_counter" = "Hide online users counter";
 "lng_settings_hide_stories" = "Hide Stories";
+"lng_settings_dontopen_stories" = "Do not open Stories";
 "lng_settings_translate_to_tc" = "使用正體中文翻譯訊息";
 "lng_settings_restart_hint" = "WARNING: Changing options that are colored in red will take effect only after the app restarts.";
 

--- a/Telegram/Resources/langs/localization/en.json
+++ b/Telegram/Resources/langs/localization/en.json
@@ -29,6 +29,7 @@
     "lng_settings_show_seconds": "Time with seconds",
     "lng_settings_hide_counter": "Hide online users counter",
     "lng_settings_hide_stories": "Hide Stories",
+	"lng_settings_dontopen_stories": "Do not open Stories",
     "lng_settings_restart_hint": "WARNING: Changing options that are colored in red will take effect only after the app restarts.",
 
     "lng_settings_skip_message": "Skip to next unread chat",

--- a/Telegram/SourceFiles/core/enhanced_settings.cpp
+++ b/Telegram/SourceFiles/core/enhanced_settings.cpp
@@ -322,6 +322,7 @@ namespace EnhancedSettings {
 		settings.insert(qsl("hide_counter"), false);
 		settings.insert(qsl("translate_to_tc"), false);
 		settings.insert(qsl("hide_stories"), false);
+		settings.insert(qsl("dontopen_stories"), false);
 
 		auto document = QJsonDocument();
 		document.setObject(settings);
@@ -372,6 +373,7 @@ namespace EnhancedSettings {
 		settings.insert(qsl("hide_counter"), GetEnhancedBool("hide_counter"));
 		settings.insert(qsl("translate_to_tc"), GetEnhancedBool("translate_to_tc"));
 		settings.insert(qsl("hide_stories"), GetEnhancedBool("hide_stories"));
+		settings.insert(qsl("dontopen_stories"), GetEnhancedBool("dontopen_stories"));
 
 		auto document = QJsonDocument();
 		document.setObject(settings);

--- a/Telegram/SourceFiles/settings/settings_enhanced.cpp
+++ b/Telegram/SourceFiles/settings/settings_enhanced.cpp
@@ -552,6 +552,20 @@ namespace Settings {
 			EnhancedSettings::Write();
 		}, container->lifetime());
 
+		AddButton(
+				container,
+				  tr::lng_settings_dontopen_stories(),
+				st::settingsButtonNoIcon
+		)->toggleOn(
+				rpl::single(GetEnhancedBool("dontopen_stories"))
+		)->toggledValue(
+		) | rpl::filter([](bool enabled) {
+			return (enabled != GetEnhancedBool("dontopen_stories"));
+		}) | rpl::start_with_next([=](bool enabled) {
+			SetEnhancedValue("dontopen_stories", enabled);
+			EnhancedSettings::Write();
+		}, container->lifetime());
+
 		AddSkip(container);
 	}
 

--- a/Telegram/SourceFiles/window/window_session_controller.cpp
+++ b/Telegram/SourceFiles/window/window_session_controller.cpp
@@ -2725,6 +2725,9 @@ void SessionController::openPeerStory(
 void SessionController::openPeerStories(
 		PeerId peerId,
 		std::optional<Data::StorySourcesList> list) {
+	if (GetEnhancedBool("dontopen_stories")) {
+		return;
+	}
 	using namespace Media::View;
 	using namespace Data;
 


### PR DESCRIPTION
This PR adds a new settings "Do not open stories".
Even if "Hide Stories" is on in the Enhanced Settings, you can still open a story by accident by tapping on an avatar of a channel or person which has a story.
This new setting completely disables the ability to open stories.