### PR TITLE
Enable 2560px by default

### DIFF
--- a/Telegram/SourceFiles/storage/localimageloader.cpp
+++ b/Telegram/SourceFiles/storage/localimageloader.cpp
@@ -55,6 +55,7 @@ base::options::toggle SendLargePhotos({
 	.id = kOptionSendLargePhotos,
 	.name = "Send large photos",
 	.description = "Increase the side limit on compressed images to 2560px.",
+	.defaultValue = true,
 });
 std::atomic<bool> SendLargePhotosAtomic/* = false*/;
 


### PR DESCRIPTION
Consider enabling this option by default. There is no reason to keep this disabled, it has been working fine without any problems for several years. It makes the sent pictures look so much better