### PR TITLE
fix: `maxSignatureSize` width

### DIFF
--- a/Telegram/SourceFiles/ui/chat/chat.style
+++ b/Telegram/SourceFiles/ui/chat/chat.style
@@ -186,7 +186,7 @@ maxStickerSize: 256px;
 maxAnimatedEmojiSize: 112px;
 maxGifSize: 320px;
 maxVideoMessageSize: 240px;
-maxSignatureSize: 144px;
+maxSignatureSize: 262px;
 maxWallPaperWidth: 160px;
 maxWallPaperHeight: 240px;
 historyThemeSize: size(272px, 176px);


### PR DESCRIPTION
due to `Show message ID` and `Time with Seconds` adding more characters to view bottom info, author info might be hidden if width is too long, adding 118px (approximate width for extra info) to `maxSignatureSize` to fix this