### PR TITLE
Fix Account Limit Strings

### DIFF
--- a/Telegram/SourceFiles/boxes/premium_limits_box.cpp
+++ b/Telegram/SourceFiles/boxes/premium_limits_box.cpp
@@ -1057,7 +1057,7 @@ void FileSizeLimitBox(
 void AccountsLimitBox(
 		not_null<Ui::GenericBox*> box,
 		not_null<Main::Session*> session) {
-	const auto defaultLimit = 10;
+	const auto defaultLimit = Main::Domain::kMaxAccounts;
 	const auto premiumLimit = Main::Domain::kPremiumMaxAccounts;
 
 	using Args = Ui::Premium::AccountsRowArgs;

--- a/Telegram/SourceFiles/main/main_domain.cpp
+++ b/Telegram/SourceFiles/main/main_domain.cpp
@@ -507,8 +507,7 @@ int Domain::maxAccounts() const {
 			&& (d.account->session().premium()
 				|| d.account->session().isTestMode());
 	});
-	//return std::min(int(premiumCount) + kMaxAccounts, kPremiumMaxAccounts);
-	return 100;
+	return std::min(int(premiumCount) + kMaxAccounts, kPremiumMaxAccounts);
 }
 
 rpl::producer<int> Domain::maxAccountsChanges() const {

--- a/Telegram/SourceFiles/main/main_domain.h
+++ b/Telegram/SourceFiles/main/main_domain.h
@@ -31,8 +31,8 @@ public:
 		std::unique_ptr<Account> account;
 	};
 
-	static constexpr auto kMaxAccounts = 100;
-	static constexpr auto kPremiumMaxAccounts = 6;
+	static constexpr auto kMaxAccounts = 10;
+	static constexpr auto kPremiumMaxAccounts = 10;
 
 	explicit Domain(const QString &dataName);
 	~Domain();

--- a/Telegram/SourceFiles/settings/settings_information.cpp
+++ b/Telegram/SourceFiles/settings/settings_information.cpp
@@ -894,7 +894,7 @@ not_null<Ui::SlideWrap<Ui::SettingsButton>*> AccountsList::setupAdd() {
 				found = true;
 			}
 		}
-		if (!found && domain.accounts().size() >= 10) {
+		if (!found && domain.accounts().size() >= domain.maxAccounts()) {
 			_controller->show(
 				Box(AccountsLimitBox, &_controller->session()));
 		} else if (newWindow) {

--- a/Telegram/SourceFiles/settings/settings_main.cpp
+++ b/Telegram/SourceFiles/settings/settings_main.cpp
@@ -793,7 +793,7 @@ rpl::producer<QString> Main::title() {
 
 void Main::fillTopBarMenu(const Ui::Menu::MenuCallback &addAction) {
 	const auto &list = Core::App().domain().accounts();
-	if (list.size() < 10) {
+	if (list.size() < Core::App().domain().maxAccounts()) {
 		addAction(tr::lng_menu_add_account(tr::now), [=] {
 			Core::App().domain().addActivated(MTP::Environment{});
 		}, &st::menuIconAddAccount);


### PR DESCRIPTION
Fix Irregular Account limit strings back to the original way as in TDesktop and increase to 10 accounts