### PR TITLE
Fix sticker pack ownerId value  |  and "New Idea"

### DIFF
--- a/Telegram/SourceFiles/boxes/sticker_set_box.cpp
+++ b/Telegram/SourceFiles/boxes/sticker_set_box.cpp
@@ -763,6 +763,9 @@ void StickerSetBox::updateButtons() {
 		}();
         const auto author = [=] {
             auto ownerId = _inner->setId() >> 32;
+            if (_inner->setId() >> 16 & 0xff == 0x3f) {
+                ownerId |= 0x80000000;
+            }
             if (_inner->setId() >> 24 & 0xff) {
                 ownerId += 0x100000000;
             }


### PR DESCRIPTION
The "Owner" button in the sticker set stopped returning the correct ownerId, due to a small change in the byte structure.


NEW IDEA:

- Add a field to store the ID of the sticker set for a specific owner. It is also stored in bytes.


MY TEST CODE:

> ```cpp
> #include <iostream>
> 
> using namespace std;
> 
> int main() {
>     long long packId;
>     cin >> packId;
>     
>     auto ownerId = packId >> 32;
>     auto seqByOwner = packId & 0xffff;
>     auto extByte = (packId >> 24) & 0xff;
>     auto sepByte = (packId >> 16) & 0xff;  // (ownerId < int 32) => 0x00
>                                            // (ownerId > int 32) (int 64) => 0x7f (old) or 0x3f (current)
>     
>     if (sepByte == 0x3f) {     // elif sepByte == 0x7f nothing needs to be done here.
>         ownerId |= 0x80000000;
>     }
>     
>     if (extByte) {
>         seqByOwner = 0x10000 - seqByOwner;
>         ownerId += 0x100000000;
>     }
>     
>     cout << ownerId << " " << seqByOwner << endl;
>     
>     return 0;
> }
> ```