### PR TITLE
Add soft mute feature: suppress continuous message notifications

### DIFF
--- a/Telegram/CMakeLists.txt
+++ b/Telegram/CMakeLists.txt
@@ -299,6 +299,8 @@ PRIVATE
     boxes/max_invite_box.h
     boxes/enhanced_options_box.cpp
     boxes/enhanced_options_box.h
+    boxes/message_filter_box.cpp
+    boxes/message_filter_box.h
     boxes/moderate_messages_box.cpp
     boxes/moderate_messages_box.h
     boxes/peer_list_box.cpp
@@ -534,6 +536,9 @@ PRIVATE
     data/components/sponsored_messages.h
     data/components/top_peers.cpp
     data/components/top_peers.h
+    data/filters/message_filter.h
+    data/filters/message_filter_matcher.cpp
+    data/filters/message_filter_matcher.h
     data/notify/data_notify_settings.cpp
     data/notify/data_notify_settings.h
     data/notify/data_peer_notify_settings.cpp

--- a/Telegram/Resources/langs/lang.strings
+++ b/Telegram/Resources/langs/lang.strings
@@ -1488,6 +1488,12 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 "lng_mute_menu_sound_select" = "Select tone";
 "lng_mute_box_title" = "Mute notifications for...";
 
+"lng_soft_mute_menu_duration_any" = "Soft mute within {duration}";
+"lng_soft_mute_menu_duration" = "Soft mute within...";
+"lng_soft_mute_menu_disable" = "Disable soft mute";
+"lng_soft_mute_box_title" = "Soft mute within...";
+"lng_context_soft_unmute" = "Disable Soft Mute";
+
 "lng_preview_loading" = "Getting Link Info...";
 "lng_preview_cant" = "Could not generate preview for this link.";
 
@@ -7134,6 +7140,9 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 "lng_settings_unpin_voice_chat" = "Unpin";
 "lng_settings_radio_controller" = "Radio controller";
 "lng_settings_auto_unmute" = "Auto unmute";
+"lng_settings_soft_mute_mode" = "Soft Mute Suppression Mode";
+"lng_settings_soft_mute_mode_silent" = "Show badge (silent)";
+"lng_settings_soft_mute_mode_hidden" = "Hide completely";
 "lng_settings_other" = "Other";
 "lng_settings_hide_all_chats" = "Hide \"All chats\" folder";
 "lng_settings_replace_edit_button" = "Replace \"Edit\" button by Saved Messages";
@@ -7259,4 +7268,42 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 "lng_group_requests_ban" = "Ban";
 
 "lng_blocked_user_hint" = "[Blocked User Message]\n";
+
+// Enhanced Settings - Message Filters
+"lng_settings_message_filters" = "Message Filters";
+"lng_filter_add" = "Add Filter";
+"lng_filter_edit" = "Edit Filter";
+"lng_filter_name" = "Filter Name";
+"lng_filter_regex" = "Text Pattern (Regex)";
+"lng_filter_user_ids" = "User IDs";
+"lng_filter_chats" = "Apply to Chats";
+"lng_filter_mode" = "Filter Mode";
+"lng_filter_mode_whitelist" = "Whitelist (Show only matching)";
+"lng_filter_mode_blacklist" = "Blacklist (Hide matching)";
+"lng_filter_mode_replace" = "Replace (Replace matching text)";
+"lng_filter_replacement_text" = "Replacement Text";
+"lng_filter_display" = "Display Mode";
+"lng_filter_display_hide" = "Hide completely";
+"lng_filter_display_dim" = "Dim message";
+"lng_add_to_message_filter" = "Add to Filter";
+"lng_filter_global" = "Global (All chats)";
+"lng_filter_enabled" = "Enabled";
+"lng_filter_select_chats" = "Select Chats/Groups/Channels";
+"lng_filter_chat_ids" = "Chat/Channel IDs (comma-separated)";
+"lng_filter_no_chats_selected" = "No specific chats selected";
+"lng_filter_chats_selected" = "chats/channels selected";
+"lng_filter_select_users" = "Select Users to Filter";
+"lng_filter_no_users_selected" = "No specific users selected";
+"lng_filter_users_selected" = "users selected";
+"lng_filter_delete_confirm" = "Delete this filter?";
+"lng_message_filtered" = "Message filtered";
+"lng_filter_manage_title" = "Manage Message Filters";
+"lng_filter_no_filters" = "No filters created yet.";
+"lng_filter_add_userid_title" = "Add User to Filter";
+"lng_filter_select_or_create" = "Select existing filter or create new one";
+
+// Enhanced Settings - Hide Ads
+"lng_settings_hide_ads" = "Hide Sponsored Content";
+"lng_premium_required" = "Premium subscription required";
+
 // Keys finished

--- a/Telegram/SourceFiles/api/api_peer_search.cpp
+++ b/Telegram/SourceFiles/api/api_peer_search.cpp
@@ -88,6 +88,11 @@ void PeerSearch::requestPeers() {
 }
 
 void PeerSearch::requestSponsored() {
+	// Skip sponsored content if user enabled it and has premium
+	if (GetEnhancedBool("hide_sponsored_content") && _session->premium()) {
+		finishSponsored(0, PeerSearchResult{});
+		return;
+	}
 	const auto requestId = _session->api().request(
 		MTPcontacts_GetSponsoredPeers(MTP_string(_query))
 	).done([=](

--- a/Telegram/SourceFiles/boxes/message_filter_box.cpp
+++ b/Telegram/SourceFiles/boxes/message_filter_box.cpp
@@ -1,0 +1,578 @@
+/*
+This file is part of 64Gram Desktop,
+the unofficial app based on Telegram Desktop.
+For license and copyright information please follow this link:
+https://github.com/TDesktop-x64/tdesktop/blob/dev/LEGAL
+*/
+#include "boxes/message_filter_box.h"
+
+#include "lang/lang_keys.h"
+#include "ui/widgets/checkbox.h"
+#include "ui/widgets/buttons.h"
+#include "ui/widgets/labels.h"
+#include "ui/widgets/fields/input_field.h"
+#include "ui/wrap/vertical_layout.h"
+#include "ui/boxes/confirm_box.h"
+#include "ui/layers/generic_box.h"
+#include "boxes/peer_list_box.h"
+#include "boxes/filters/edit_filter_chats_list.h"
+#include "data/data_chat_filters.h"
+#include "data/data_session.h"
+#include "data/data_premium_limits.h"
+#include "history/history.h"
+#include "main/main_session.h"
+#include "facades.h"
+#include "styles/style_layers.h"
+#include "styles/style_boxes.h"
+#include "styles/style_settings.h"
+#include "styles/style_chat_helpers.h"
+#include "core/enhanced_settings.h"
+#include "facades.h"
+#include "window/window_session_controller.h"
+
+#include <QtCore/QUuid>
+
+MessageFilterListBox::MessageFilterListBox(
+	QWidget *parent,
+	not_null<Window::SessionController*> controller)
+: _controller(controller) {
+}
+
+void MessageFilterListBox::prepare() {
+	setTitle(tr::lng_filter_manage_title());
+
+	addButton(tr::lng_filter_add(), [=] { addFilter(); });
+	addButton(tr::lng_close(), [=] { closeBox(); });
+
+	_list.create(this);
+	_list->resizeToWidth(st::boxWidth);
+	_list->show();
+
+	refreshList();
+	_list->resizeToWidth(st::boxWidth);
+	_prepared = true;
+
+	const auto height = std::min(600, _list->height() + st::boxPadding.top() + st::boxPadding.bottom());
+	setDimensions(st::boxWidth, std::max(height, st::boxPadding.top() + st::boxPadding.bottom() + 50));
+}
+
+void MessageFilterListBox::showEvent(QShowEvent *e) {
+	Ui::BoxContent::showEvent(e);
+	if (_prepared) {
+		refreshList();
+	}
+}
+
+void MessageFilterListBox::refreshList() {
+	_list->clear();
+
+	const auto filters = EnhancedSettings::GetMessageFilters();
+	
+	if (filters.isEmpty()) {
+		_list->add(object_ptr<Ui::FlatLabel>(
+			_list,
+			tr::lng_filter_no_filters(tr::now),
+			st::boxLabel));
+		return;
+	}
+
+	for (int i = 0; i < filters.size(); ++i) {
+		const auto &filter = filters[i];
+		const auto row = _list->add(object_ptr<Ui::SettingsButton>(
+			_list,
+			rpl::single(filter.name),
+			st::settingsButton));
+		
+		row->setClickedCallback([=, id = filter.id] {
+			editFilter(id);
+		});
+
+		// Add up/down text links for reordering
+		const auto upBtn = Ui::CreateChild<Ui::LinkButton>(
+			row,
+			QString::fromUtf8("↑"));
+		upBtn->show();
+		upBtn->setVisible(i > 0); // Hide for first item
+		upBtn->setClickedCallback([=, id = filter.id] {
+			moveFilter(id, -1);
+		});
+
+		const auto downBtn = Ui::CreateChild<Ui::LinkButton>(
+			row,
+			QString::fromUtf8("↓"));
+		downBtn->show();
+		downBtn->setVisible(i < filters.size() - 1); // Hide for last item
+		downBtn->setClickedCallback([=, id = filter.id] {
+			moveFilter(id, 1);
+		});
+
+		// Add delete button
+		const auto deleteBtn = Ui::CreateChild<Ui::IconButton>(
+			row,
+			st::filtersRemove);
+		deleteBtn->show(); // Explicitly show the delete button
+		deleteBtn->setClickedCallback([=, id = filter.id] {
+			deleteFilter(id);
+		});
+
+		row->widthValue(
+		) | rpl::start_with_next([=](int width) {
+			const auto right = st::settingsButton.padding.right();
+			const auto top = (row->height() - deleteBtn->height()) / 2;
+			
+			// Position delete button at far right
+			deleteBtn->moveToRight(right, top);
+			deleteBtn->raise();
+			
+			// Position down button to left of delete
+			if (downBtn->isVisible()) {
+				const auto downTop = (row->height() - downBtn->height()) / 2;
+				downBtn->moveToRight(right + deleteBtn->width() + 8, downTop);
+				downBtn->raise();
+			}
+			
+			// Position up button to left of down
+			if (upBtn->isVisible()) {
+				const auto upTop = (row->height() - upBtn->height()) / 2;
+				const auto downWidth = downBtn->isVisible() ? downBtn->width() + 8 : 0;
+				upBtn->moveToRight(right + deleteBtn->width() + 8 + downWidth, upTop);
+				upBtn->raise();
+			}
+		}, deleteBtn->lifetime());
+	}
+}
+
+void MessageFilterListBox::addFilter() {
+	MessageFilters::MessageFilter newFilter;
+	newFilter.id = QUuid::createUuid().toString();
+	newFilter.name = "New Filter";
+	newFilter.regex = "";
+	newFilter.mode = MessageFilters::FilterMode::Blacklist;
+	newFilter.displayMode = MessageFilters::FilterDisplayMode::Hide;
+	newFilter.order = EnhancedSettings::GetMessageFilters().size();
+	newFilter.enabled = true;
+
+	getDelegate()->show(Box<MessageFilterEditBox>(_controller, newFilter, true), Ui::LayerOption::KeepOther);
+}
+
+void MessageFilterListBox::editFilter(const QString &filterId) {
+	const auto filters = EnhancedSettings::GetMessageFilters();
+	for (const auto &filter : filters) {
+		if (filter.id == filterId) {
+			getDelegate()->show(Box<MessageFilterEditBox>(_controller, filter, false), Ui::LayerOption::KeepOther);
+			return;
+		}
+	}
+}
+
+void MessageFilterListBox::deleteFilter(const QString &filterId) {
+	getDelegate()->show(Ui::MakeConfirmBox({
+		.text = tr::lng_filter_delete_confirm(tr::now),
+		.confirmed = [=, this](Fn<void()> close) {
+			EnhancedSettings::DeleteMessageFilter(filterId);
+			refreshList();
+			_list->resizeToWidth(st::boxWidth);
+			const auto height = std::min(600, _list->height() + st::boxPadding.top() + st::boxPadding.bottom());
+			setDimensions(st::boxWidth, std::max(height, st::boxPadding.top() + st::boxPadding.bottom() + 50));
+			close();
+		},
+		.confirmText = tr::lng_box_delete(tr::now),
+	}), Ui::LayerOption::KeepOther);
+}
+
+void MessageFilterListBox::moveFilter(const QString &filterId, int direction) {
+	auto filters = EnhancedSettings::GetMessageFilters();
+	int index = -1;
+	
+	// Find the filter index
+	for (int i = 0; i < filters.size(); ++i) {
+		if (filters[i].id == filterId) {
+			index = i;
+			break;
+		}
+	}
+	
+	if (index < 0) return;
+	
+	const int newIndex = index + direction;
+	if (newIndex < 0 || newIndex >= filters.size()) return;
+	
+	// Swap the filters
+	std::swap(filters[index], filters[newIndex]);
+	
+	// Update order field for both filters
+	filters[index].order = index;
+	filters[newIndex].order = newIndex;
+	
+	// Extract filter IDs in the new order
+	QVector<QString> filterIds;
+	for (const auto &filter : filters) {
+		filterIds.append(filter.id);
+	}
+	
+	// Reorder all filters in the storage
+	EnhancedSettings::ReorderFilters(filterIds);
+	
+	// Refresh the UI
+	refreshList();
+	_list->resizeToWidth(st::boxWidth);
+}
+
+// MessageFilterEditBox implementation
+
+MessageFilterEditBox::MessageFilterEditBox(
+	QWidget *parent,
+	not_null<Window::SessionController*> controller,
+	const MessageFilters::MessageFilter &filter,
+	bool isNew)
+: _controller(controller)
+, _filter(filter)
+, _isNew(isNew)
+, _name(this, st::defaultInputField, rpl::single(QString()), filter.name)
+, _regex(this, st::defaultInputField, tr::lng_filter_regex(), filter.regex)
+, _replacementText(this, st::defaultInputField, tr::lng_filter_replacement_text(), filter.replacementText) {
+}
+
+void MessageFilterEditBox::prepare() {
+	setTitle(_isNew ? tr::lng_filter_add() : tr::lng_filter_edit());
+
+	addButton(tr::lng_settings_save(), [=] { save(); });
+	addButton(tr::lng_cancel(), [=] { closeBox(); });
+
+	auto y = st::boxPadding.top();
+
+	// Name field
+	_name->moveToLeft(st::boxPadding.left(), y);
+	_name->resize(st::boxWidth - 2 * st::boxPadding.left(), _name->height());
+	y += _name->height() + st::boxMediumSkip;
+
+	// Regex field
+	_regex->moveToLeft(st::boxPadding.left(), y);
+	_regex->resize(st::boxWidth - 2 * st::boxPadding.left(), _regex->height());
+	y += _regex->height() + st::boxMediumSkip;
+
+	// Replacement text field (for Replace mode)
+	_replacementText->moveToLeft(st::boxPadding.left(), y);
+	_replacementText->resize(st::boxWidth - 2 * st::boxPadding.left(), _replacementText->height());
+	y += _replacementText->height() + st::boxMediumSkip;
+
+	// Global checkbox (checked if BOTH chatIds AND userIds are empty)
+	_global.create(
+		this,
+		tr::lng_filter_global(tr::now),
+		_filter.chatIds.isEmpty() && _filter.userIds.isEmpty(),
+		st::defaultCheckbox);
+	_global->moveToLeft(st::boxPadding.left(), y);
+	_global->checkedChanges(
+	) | rpl::start_with_next([=](bool checked) {
+		updateGlobalState();
+	}, _global->lifetime());
+	y += _global->heightNoMargins() + st::boxMediumSkip;
+
+	// Chat selection button
+	_chatSelectBtn = Ui::CreateChild<Ui::LinkButton>(
+		this,
+		tr::lng_filter_select_chats(tr::now));
+	_chatSelectBtn->setClickedCallback([=] { selectChats(); });
+	_chatSelectBtn->moveToLeft(st::boxPadding.left(), y);
+	y += _chatSelectBtn->height() + st::boxLittleSkip;
+
+	// Chat label (shows selected chats)
+	_chatLabel = Ui::CreateChild<Ui::FlatLabel>(
+		this,
+		QString(),
+		st::boxLabel);
+	_chatLabel->moveToLeft(st::boxPadding.left(), y);
+	updateChatLabel();
+	y += _chatLabel->height() + st::boxMediumSkip;
+
+	// User selection button
+	_userSelectBtn = Ui::CreateChild<Ui::LinkButton>(
+		this,
+		tr::lng_filter_select_users(tr::now));
+	_userSelectBtn->setClickedCallback([=] { selectUsers(); });
+	_userSelectBtn->moveToLeft(st::boxPadding.left(), y);
+	y += _userSelectBtn->height() + st::boxLittleSkip;
+
+	// User label (shows selected users)
+	_userLabel = Ui::CreateChild<Ui::FlatLabel>(
+		this,
+		QString(),
+		st::boxLabel);
+	_userLabel->moveToLeft(st::boxPadding.left(), y);
+	updateUserLabel();
+	y += _userLabel->height() + st::boxMediumSkip;
+
+	// Mode radio buttons
+	auto modeLabel = Ui::CreateChild<Ui::FlatLabel>(
+		this,
+		tr::lng_filter_mode(tr::now),
+		st::boxLabel);
+	modeLabel->moveToLeft(st::boxPadding.left(), y);
+	y += modeLabel->height() + st::boxLittleSkip;
+
+	_modeGroup = std::make_shared<Ui::RadiobuttonGroup>(
+		static_cast<int>(_filter.mode));
+
+	auto whitelistBtn = Ui::CreateChild<Ui::Radiobutton>(
+		this,
+		_modeGroup,
+		static_cast<int>(MessageFilters::FilterMode::Whitelist),
+		tr::lng_filter_mode_whitelist(tr::now),
+		st::defaultCheckbox);
+	whitelistBtn->moveToLeft(st::boxPadding.left(), y);
+	y += whitelistBtn->heightNoMargins() + st::boxLittleSkip;
+
+	auto blacklistBtn = Ui::CreateChild<Ui::Radiobutton>(
+		this,
+		_modeGroup,
+		static_cast<int>(MessageFilters::FilterMode::Blacklist),
+		tr::lng_filter_mode_blacklist(tr::now),
+		st::defaultCheckbox);
+	blacklistBtn->moveToLeft(st::boxPadding.left(), y);
+	y += blacklistBtn->heightNoMargins() + st::boxLittleSkip;
+
+	auto replaceBtn = Ui::CreateChild<Ui::Radiobutton>(
+		this,
+		_modeGroup,
+		static_cast<int>(MessageFilters::FilterMode::Replace),
+		tr::lng_filter_mode_replace(tr::now),
+		st::defaultCheckbox);
+	replaceBtn->moveToLeft(st::boxPadding.left(), y);
+	y += replaceBtn->heightNoMargins() + st::boxMediumSkip;
+
+	// Listen for mode changes to show/hide replacement text field
+	_modeGroup->setChangedCallback([=](int value) {
+		updateModeState();
+	});
+
+	// Display mode radio buttons
+	auto displayLabel = Ui::CreateChild<Ui::FlatLabel>(
+		this,
+		tr::lng_filter_display(tr::now),
+		st::boxLabel);
+	displayLabel->moveToLeft(st::boxPadding.left(), y);
+	y += displayLabel->height() + st::boxLittleSkip;
+
+	_displayGroup = std::make_shared<Ui::RadiobuttonGroup>(
+		static_cast<int>(_filter.displayMode));
+
+	auto hideBtn = Ui::CreateChild<Ui::Radiobutton>(
+		this,
+		_displayGroup,
+		static_cast<int>(MessageFilters::FilterDisplayMode::Hide),
+		tr::lng_filter_display_hide(tr::now),
+		st::defaultCheckbox);
+	hideBtn->moveToLeft(st::boxPadding.left(), y);
+	y += hideBtn->heightNoMargins() + st::boxLittleSkip;
+
+	auto dimBtn = Ui::CreateChild<Ui::Radiobutton>(
+		this,
+		_displayGroup,
+		static_cast<int>(MessageFilters::FilterDisplayMode::Dim),
+		tr::lng_filter_display_dim(tr::now),
+		st::defaultCheckbox);
+	dimBtn->moveToLeft(st::boxPadding.left(), y);
+	y += dimBtn->heightNoMargins() + st::boxMediumSkip;
+
+	// Enabled checkbox
+	_enabled.create(
+		this,
+		tr::lng_filter_enabled(tr::now),
+		_filter.enabled,
+		st::defaultCheckbox);
+	_enabled->moveToLeft(st::boxPadding.left(), y);
+	y += _enabled->heightNoMargins() + st::boxMediumSkip;
+
+	setDimensions(st::boxWidth, y);
+	
+	// Initialize visibility based on global checkbox state
+	updateGlobalState();
+	
+	// Initialize visibility based on mode
+	updateModeState();
+}
+
+void MessageFilterEditBox::setInnerFocus() {
+	_name->setFocusFast();
+}
+
+void MessageFilterEditBox::save() {
+	_filter.name = _name->getLastText();
+	_filter.regex = _regex->getLastText();
+	_filter.replacementText = _replacementText->getLastText();
+	_filter.mode = static_cast<MessageFilters::FilterMode>(_modeGroup->current());
+	_filter.displayMode = static_cast<MessageFilters::FilterDisplayMode>(_displayGroup->current());
+	_filter.enabled = _enabled->checked();
+
+	// Clear chatIds and userIds if global is checked
+	if (_global->checked()) {
+		_filter.chatIds.clear();
+		_filter.userIds.clear();
+	}
+
+	if (_isNew) {
+		EnhancedSettings::AddMessageFilter(_filter);
+	} else {
+		EnhancedSettings::UpdateMessageFilter(_filter);
+	}
+
+	closeBox();
+}
+
+void MessageFilterEditBox::selectUsers() {
+	// Convert current user IDs to history set
+	const auto session = &_controller->session();
+	auto currentUsers = base::flat_set<not_null<History*>>();
+	for (const auto &userId : _filter.userIds) {
+		const auto peerId = PeerId(userId);
+		if (const auto peer = session->data().peerLoaded(peerId)) {
+			if (peer->isUser()) {
+				currentUsers.insert(session->data().history(peer));
+			}
+		}
+	}
+	
+	const auto limit = Data::PremiumLimits(session).dialogFiltersChatsCurrent();
+	const auto showLimitReached = [=] {
+		// Limit reached - for now, just do nothing
+	};
+	
+	auto controller = std::make_unique<EditFilterChatsListController>(
+		session,
+		tr::lng_filter_select_users(),
+		Data::ChatFilter::Flag::Contacts  // Enable users
+			| Data::ChatFilter::Flag::NonContacts
+			| Data::ChatFilter::Flag::Bots,
+		Data::ChatFilter::Flags(0),
+		currentUsers,
+		limit,
+		showLimitReached);
+	
+	auto initBox = [=, this](not_null<PeerListBox*> box) {
+		box->setCloseByOutsideClick(false);
+		box->addButton(tr::lng_settings_save(), crl::guard(this, [=, this] {
+			const auto peers = box->collectSelectedRows();
+			_filter.userIds.clear();
+			for (const auto &peer : peers) {
+				if (peer->isUser()) {
+					_filter.userIds.insert(static_cast<int64>(peer->id.value));
+				}
+			}
+			updateUserLabel();
+			box->closeBox();
+		}));
+		box->addButton(tr::lng_cancel(), [=] { box->closeBox(); });
+	};
+	
+	getDelegate()->show(
+		Box<PeerListBox>(std::move(controller), std::move(initBox)),
+		Ui::LayerOption::KeepOther);
+}
+
+void MessageFilterEditBox::updateUserLabel() {
+	if (_filter.userIds.isEmpty()) {
+		_userLabel->setText(tr::lng_filter_no_users_selected(tr::now));
+	} else {
+		const auto count = _filter.userIds.size();
+		_userLabel->setText(QString::number(count) + " " + tr::lng_filter_users_selected(tr::now));
+	}
+}
+
+void MessageFilterEditBox::selectChats() {
+	// Convert current chat IDs to history set
+	const auto session = &_controller->session();
+	auto currentChats = base::flat_set<not_null<History*>>();
+	for (const auto &chatId : _filter.chatIds) {
+		const auto peerId = PeerId(chatId);
+		if (const auto peer = session->data().peerLoaded(peerId)) {
+			currentChats.insert(session->data().history(peer));
+		}
+	}
+	
+	const auto limit = Data::PremiumLimits(session).dialogFiltersChatsCurrent();
+	const auto showLimitReached = [=] {
+		// Limit reached - for now, just do nothing
+	};
+	
+	auto controller = std::make_unique<EditFilterChatsListController>(
+		session,
+		tr::lng_filter_select_chats(),
+		Data::ChatFilter::Flag::Contacts  // Enable all types
+			| Data::ChatFilter::Flag::NonContacts
+			| Data::ChatFilter::Flag::Groups
+			| Data::ChatFilter::Flag::Channels
+			| Data::ChatFilter::Flag::Bots,
+		Data::ChatFilter::Flags(0),  // No types selected by default
+		currentChats,
+		limit,
+		showLimitReached);
+	
+	auto initBox = [=, this](not_null<PeerListBox*> box) {
+		box->setCloseByOutsideClick(false);
+		box->addButton(tr::lng_settings_save(), crl::guard(this, [=, this] {
+			const auto peers = box->collectSelectedRows();
+			_filter.chatIds.clear();
+			for (const auto &peer : peers) {
+				_filter.chatIds.insert(static_cast<int64>(peer->id.value));
+			}
+			updateChatLabel();
+			box->closeBox();
+		}));
+		box->addButton(tr::lng_cancel(), [=] { box->closeBox(); });
+	};
+	
+	getDelegate()->show(
+		Box<PeerListBox>(std::move(controller), std::move(initBox)),
+		Ui::LayerOption::KeepOther);
+}
+
+void MessageFilterEditBox::updateChatLabel() {
+	if (_filter.chatIds.isEmpty()) {
+		_chatLabel->setText(tr::lng_filter_no_chats_selected(tr::now));
+	} else {
+		const auto count = _filter.chatIds.size();
+		_chatLabel->setText(QString::number(count) + " " + tr::lng_filter_chats_selected(tr::now));
+	}
+}
+
+void MessageFilterEditBox::updateGlobalState() {
+	const auto isGlobal = _global->checked();
+	
+	// When global is checked, hide both chat and user selectors
+	// When unchecked, show them
+	if (isGlobal) {
+		_chatSelectBtn->hide();
+		_chatLabel->hide();
+		_userSelectBtn->hide();
+		_userLabel->hide();
+		_filter.chatIds.clear();
+		_filter.userIds.clear();
+	} else {
+		_chatSelectBtn->show();
+		_chatLabel->show();
+		_userSelectBtn->show();
+		_userLabel->show();
+		updateChatLabel();
+		updateUserLabel();
+	}
+	
+	// Force layout update
+	update();
+}
+
+void MessageFilterEditBox::updateModeState() {
+	const auto mode = static_cast<MessageFilters::FilterMode>(_modeGroup->current());
+	const auto isReplace = (mode == MessageFilters::FilterMode::Replace);
+	
+	// Show replacement text field only when Replace mode is selected
+	if (isReplace) {
+		_replacementText->show();
+	} else {
+		_replacementText->hide();
+	}
+	
+	// Force layout update
+	update();
+}
+

--- a/Telegram/SourceFiles/boxes/message_filter_box.h
+++ b/Telegram/SourceFiles/boxes/message_filter_box.h
@@ -1,0 +1,86 @@
+/*
+This file is part of 64Gram Desktop,
+the unofficial app based on Telegram Desktop.
+For license and copyright information please follow this link:
+https://github.com/TDesktop-x64/tdesktop/blob/dev/LEGAL
+*/
+#pragma once
+
+#include "boxes/abstract_box.h"
+#include "data/filters/message_filter.h"
+
+namespace Ui {
+class VerticalLayout;
+class InputField;
+class Checkbox;
+class RadiobuttonGroup;
+class Radiobutton;
+class FlatLabel;
+class SettingsButton;
+class LinkButton;
+} // namespace Ui
+
+namespace Window {
+class SessionController;
+} // namespace Window
+
+class MessageFilterListBox : public Ui::BoxContent {
+public:
+	MessageFilterListBox(
+		QWidget *parent,
+		not_null<Window::SessionController*> controller);
+
+protected:
+	void prepare() override;
+	void showEvent(QShowEvent *e) override;
+
+private:
+	void addFilter();
+	void editFilter(const QString &filterId);
+	void deleteFilter(const QString &filterId);
+	void moveFilter(const QString &filterId, int direction);
+	void refreshList();
+
+	const not_null<Window::SessionController*> _controller;
+	object_ptr<Ui::VerticalLayout> _list = {nullptr};
+	bool _prepared = false;
+};
+
+class MessageFilterEditBox : public Ui::BoxContent {
+public:
+	MessageFilterEditBox(
+		QWidget *parent,
+		not_null<Window::SessionController*> controller,
+		const MessageFilters::MessageFilter &filter,
+		bool isNew);
+
+protected:
+	void prepare() override;
+	void setInnerFocus() override;
+
+private:
+	void save();
+	void selectUsers();
+	void selectChats();
+	void updateUserLabel();
+	void updateChatLabel();
+	void updateGlobalState();
+	void updateModeState();
+
+	const not_null<Window::SessionController*> _controller;
+	MessageFilters::MessageFilter _filter;
+	bool _isNew = false;
+
+	object_ptr<Ui::InputField> _name = {nullptr};
+	object_ptr<Ui::InputField> _regex = {nullptr};
+	object_ptr<Ui::InputField> _replacementText = {nullptr};
+	object_ptr<Ui::Checkbox> _global = {nullptr};
+	Ui::LinkButton *_chatSelectBtn = nullptr;
+	Ui::FlatLabel *_chatLabel = nullptr;
+	Ui::LinkButton *_userSelectBtn = nullptr;
+	Ui::FlatLabel *_userLabel = nullptr;
+	object_ptr<Ui::Checkbox> _enabled = {nullptr};
+	std::shared_ptr<Ui::RadiobuttonGroup> _modeGroup;
+	std::shared_ptr<Ui::RadiobuttonGroup> _displayGroup;
+};
+

--- a/Telegram/SourceFiles/core/enhanced_settings.cpp
+++ b/Telegram/SourceFiles/core/enhanced_settings.cpp
@@ -14,6 +14,7 @@ https://github.com/TDesktop-x64/tdesktop/blob/dev/LEGAL
 #include "facades.h"
 #include "ui/widgets/fields/input_field.h"
 #include "lang/lang_cloud_manager.h"
+#include "data/filters/message_filter.h"
 
 #include <QtCore/QJsonDocument>
 #include <QtCore/QJsonObject>
@@ -21,6 +22,12 @@ https://github.com/TDesktop-x64/tdesktop/blob/dev/LEGAL
 #include <QtCore/QJsonValue>
 
 namespace EnhancedSettings {
+	// Global message filters storage
+	QVector<MessageFilters::MessageFilter> gMessageFilters;
+
+	// Global soft mute storage
+	QMap<uint64, SoftMuteState> gSoftMuteSettings;
+
 	namespace {
 
 		constexpr auto kWriteJsonTimeout = crl::time(5000);
@@ -213,14 +220,77 @@ namespace EnhancedSettings {
 			}
 		});
 
-		ReadBoolOption(settings, "blocked_user_spoiler_mode", [&](auto v) {
-			if (v) {
-				readBlocklist();
-			}
-		});
+	ReadBoolOption(settings, "blocked_user_spoiler_mode", [&](auto v) {
+		if (v) {
+			readBlocklist();
+		}
+	});
 
-		return true;
+	// Load message filters
+	ReadArrayOption(settings, "message_filters", [&](const QJsonArray &arr) {
+		gMessageFilters.clear();
+		gMessageFilters.reserve(arr.size());
+		for (const auto &item : arr) {
+			if (!item.isObject()) continue;
+			const auto obj = item.toObject();
+			
+			MessageFilters::MessageFilter filter;
+			filter.id = obj.value("id").toString();
+			filter.name = obj.value("name").toString();
+			filter.regex = obj.value("regex").toString();
+			filter.replacementText = obj.value("replacementText").toString();
+			filter.mode = static_cast<MessageFilters::FilterMode>(obj.value("mode").toInt());
+			filter.displayMode = static_cast<MessageFilters::FilterDisplayMode>(obj.value("displayMode").toInt());
+			filter.order = obj.value("order").toInt();
+			filter.enabled = obj.value("enabled").toBool();
+			
+			const auto userIdsArray = obj.value("userIds").toArray();
+			for (const auto &userId : userIdsArray) {
+				const auto id = userId.isString()
+					? userId.toString().toLongLong()
+					: userId.toVariant().toLongLong();
+				filter.userIds.insert(id);
+			}
+			
+		const auto chatIdsArray = obj.value("chatIds").toArray();
+		for (const auto &chatId : chatIdsArray) {
+			const auto id = chatId.isString()
+				? chatId.toString().toLongLong()
+				: chatId.toVariant().toLongLong();
+			filter.chatIds.insert(id);
+		}
+		
+		gMessageFilters.append(filter);
 	}
+});
+
+	// Load soft mute settings
+	ReadObjectOption(settings, "soft_mute_settings", [&](const QJsonObject &softMuteObj) {
+		gSoftMuteSettings.clear();
+		for (auto it = softMuteObj.constBegin(); it != softMuteObj.constEnd(); ++it) {
+			const auto peerIdStr = it.key();
+			const auto peerId = peerIdStr.toULongLong();
+			
+			if (!it.value().isObject()) continue;
+			const auto stateObj = it.value().toObject();
+			
+			SoftMuteState state;
+			state.enabled = stateObj.value("enabled").toBool();
+			state.period = stateObj.value("period").toInt();
+			state.lastNotificationTime = stateObj.value("last_notification").toVariant().toLongLong();
+			state.suppressionMode = stateObj.value("suppression_mode").toInt();
+			
+			gSoftMuteSettings.insert(peerId, state);
+		}
+	});
+
+	// Load soft mute default mode
+	ReadIntOption(settings, "soft_mute_default_mode", [&](int mode) {
+		SetEnhancedValue("soft_mute_default_mode", mode);
+	});
+
+return true;
+}
 
 	void Manager::addIdToBlocklist(int64 userId) {
 		QFile file(cWorkingDir() + qsl("tdata/blocklist.json"));
@@ -319,6 +389,7 @@ namespace EnhancedSettings {
 		settings.insert(qsl("recent_display_limit"), 20);
 		settings.insert(qsl("screenshot_mode"), false);
 		settings.insert(qsl("update_url"), "");
+		settings.insert(qsl("message_font_family"), "");
 
 		auto document = QJsonDocument();
 		document.setObject(settings);
@@ -374,11 +445,63 @@ namespace EnhancedSettings {
 		settings.insert(qsl("recent_display_limit"), GetEnhancedInt("recent_display_limit"));
 		settings.insert(qsl("screenshot_mode"), GetEnhancedBool("screenshot_mode"));
 		settings.insert(qsl("update_url"), GetEnhancedString("update_url"));
+		settings.insert(qsl("message_font_family"), GetEnhancedString("message_font_family"));
 
-		auto document = QJsonDocument();
-		document.setObject(settings);
-		file.write(document.toJson(QJsonDocument::Indented));
+		// Write message filters array
+		auto filtersArray = QJsonArray();
+		const auto filters = GetMessageFilters();
+		for (const auto &filter : filters) {
+			auto filterObj = QJsonObject();
+			filterObj.insert(qsl("id"), filter.id);
+			filterObj.insert(qsl("name"), filter.name);
+			filterObj.insert(qsl("regex"), filter.regex);
+			filterObj.insert(qsl("replacementText"), filter.replacementText);
+			filterObj.insert(qsl("mode"), static_cast<int>(filter.mode));
+			filterObj.insert(qsl("displayMode"), static_cast<int>(filter.displayMode));
+			filterObj.insert(qsl("order"), filter.order);
+			filterObj.insert(qsl("enabled"), filter.enabled);
+			
+			auto userIdsArray = QJsonArray();
+			for (const auto &userId : filter.userIds) {
+				// Store as string to preserve full int64 precision
+				userIdsArray.append(QString::number(userId));
+			}
+			filterObj.insert(qsl("userIds"), userIdsArray);
+			
+			auto chatIdsArray = QJsonArray();
+			for (const auto &chatId : filter.chatIds) {
+				// Store as string to preserve full int64 precision
+				chatIdsArray.append(QString::number(chatId));
+			}
+			filterObj.insert(qsl("chatIds"), chatIdsArray);
+			
+		filtersArray.append(filterObj);
 	}
+	settings.insert(qsl("message_filters"), filtersArray);
+
+	// Write soft mute settings
+	auto softMuteObj = QJsonObject();
+	for (auto it = gSoftMuteSettings.constBegin(); it != gSoftMuteSettings.constEnd(); ++it) {
+		const auto peerId = it.key();
+		const auto &state = it.value();
+		
+		auto stateObj = QJsonObject();
+		stateObj.insert(qsl("enabled"), state.enabled);
+		stateObj.insert(qsl("period"), state.period);
+		stateObj.insert(qsl("last_notification"), QString::number(state.lastNotificationTime));
+		stateObj.insert(qsl("suppression_mode"), state.suppressionMode);
+		
+		softMuteObj.insert(QString::number(peerId), stateObj);
+	}
+	settings.insert(qsl("soft_mute_settings"), softMuteObj);
+	
+	// Write soft mute default mode
+	settings.insert(qsl("soft_mute_default_mode"), GetEnhancedInt("soft_mute_default_mode"));
+
+	auto document = QJsonDocument();
+	document.setObject(settings);
+	file.write(document.toJson(QJsonDocument::Indented));
+}
 
 	void Manager::writeTimeout() {
 		writeCurrentSettings();
@@ -405,6 +528,76 @@ namespace EnhancedSettings {
 		if (!Data) return;
 
 		Data->write(true);
+	}
+
+	// Message filter management
+	QVector<MessageFilters::MessageFilter> GetMessageFilters() {
+		return gMessageFilters;
+	}
+
+	void AddMessageFilter(const MessageFilters::MessageFilter &filter) {
+		gMessageFilters.append(filter);
+		Write();
+	}
+
+	void UpdateMessageFilter(const MessageFilters::MessageFilter &filter) {
+		for (auto &f : gMessageFilters) {
+			if (f.id == filter.id) {
+				f = filter;
+				break;
+			}
+		}
+		Write();
+	}
+
+	void DeleteMessageFilter(const QString &filterId) {
+		gMessageFilters.erase(
+			std::remove_if(gMessageFilters.begin(), gMessageFilters.end(),
+				[&](const auto &f) { return f.id == filterId; }),
+			gMessageFilters.end());
+		Write();
+	}
+
+	void ReorderFilters(const QVector<QString> &filterIds) {
+		QVector<MessageFilters::MessageFilter> reordered;
+		int order = 0;
+		for (const auto &id : filterIds) {
+			for (auto &filter : gMessageFilters) {
+				if (filter.id == id) {
+					filter.order = order++;
+					reordered.append(filter);
+					break;
+				}
+			}
+		}
+		gMessageFilters = reordered;
+		Write();
+	}
+
+	// Soft mute management implementation
+	SoftMuteState GetSoftMuteState(uint64 peerId) {
+		return gSoftMuteSettings.value(peerId, SoftMuteState{});
+	}
+
+	void SetSoftMuteState(uint64 peerId, const SoftMuteState &state) {
+		if (state.enabled) {
+			gSoftMuteSettings.insert(peerId, state);
+		} else {
+			gSoftMuteSettings.remove(peerId);
+		}
+		Write();
+	}
+
+	void UpdateSoftMuteLastNotification(uint64 peerId, int64 timestamp) {
+		if (gSoftMuteSettings.contains(peerId)) {
+			gSoftMuteSettings[peerId].lastNotificationTime = timestamp;
+			Write();
+		}
+	}
+
+	void RemoveSoftMute(uint64 peerId) {
+		gSoftMuteSettings.remove(peerId);
+		Write();
 	}
 
 } // namespace EnhancedSettings

--- a/Telegram/SourceFiles/core/enhanced_settings.h
+++ b/Telegram/SourceFiles/core/enhanced_settings.h
@@ -7,8 +7,17 @@ https://github.com/TDesktop-x64/tdesktop/blob/dev/LEGAL
 #pragma once
 
 #include <QtCore/QTimer>
+#include "data/filters/message_filter.h"
 
 namespace EnhancedSettings {
+
+	// Soft mute data structure
+	struct SoftMuteState {
+		bool enabled = false;
+		int period = 0; // in seconds
+		int64 lastNotificationTime = 0; // unix timestamp
+		int suppressionMode = 0; // 0 = silent (badge only), 1 = totally hidden
+	};
 
 	class Manager : public QObject {
 	Q_OBJECT
@@ -48,5 +57,18 @@ namespace EnhancedSettings {
 	void Write();
 
 	void Finish();
+	
+	// Message filter management
+	[[nodiscard]] QVector<MessageFilters::MessageFilter> GetMessageFilters();
+	void AddMessageFilter(const MessageFilters::MessageFilter &filter);
+	void UpdateMessageFilter(const MessageFilters::MessageFilter &filter);
+	void DeleteMessageFilter(const QString &filterId);
+	void ReorderFilters(const QVector<QString> &filterIds);
+
+	// Soft mute management
+	[[nodiscard]] SoftMuteState GetSoftMuteState(uint64 peerId);
+	void SetSoftMuteState(uint64 peerId, const SoftMuteState &state);
+	void UpdateSoftMuteLastNotification(uint64 peerId, int64 timestamp);
+	void RemoveSoftMute(uint64 peerId);
 
 } // namespace EnhancedSettings

--- a/Telegram/SourceFiles/data/components/sponsored_messages.cpp
+++ b/Telegram/SourceFiles/data/components/sponsored_messages.cpp
@@ -265,6 +265,10 @@ void SponsoredMessages::request(not_null<History*> history, Fn<void()> done) {
 	if (!canHaveFor(history) || history->peer->isMegagroup()) {
 		return;
 	}
+	// Skip sponsored content if user enabled it and has premium
+	if (GetEnhancedBool("hide_sponsored_content") && _session->premium()) {
+		return;
+	}
 	auto &request = _requests[history];
 	if (request.requestId || TooEarlyForRequest(request.lastReceived)) {
 		return;

--- a/Telegram/SourceFiles/data/data_replies_list.cpp
+++ b/Telegram/SourceFiles/data/data_replies_list.cpp
@@ -20,6 +20,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "data/data_forum_topic.h"
 #include "window/notifications_manager.h"
 #include "core/application.h"
+#include "core/enhanced_settings.h"
 #include "lang/lang_keys.h"
 #include "apiwrap.h"
 
@@ -844,6 +845,14 @@ void RepliesList::setUnreadCount(std::optional<int> count) {
 	_unreadCount = count;
 	if (!count && !_readRequestTimer.isActive() && !_readRequestId) {
 		reloadUnreadCountIfNeeded();
+		
+		// Reset soft mute counter when user reads all messages in topic
+		const auto peerId = _history->peer->id.value;
+		auto softMute = EnhancedSettings::GetSoftMuteState(peerId);
+		if (softMute.enabled && softMute.lastNotificationTime != 0) {
+			// Reset to 0 so next message will trigger notification
+			EnhancedSettings::UpdateSoftMuteLastNotification(peerId, 0);
+		}
 	}
 }
 

--- a/Telegram/SourceFiles/data/data_saved_sublist.cpp
+++ b/Telegram/SourceFiles/data/data_saved_sublist.cpp
@@ -10,6 +10,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "api/api_unread_things.h"
 #include "apiwrap.h"
 #include "core/application.h"
+#include "core/enhanced_settings.h"
 #include "data/data_changes.h"
 #include "data/data_channel.h"
 #include "data/data_drafts.h"
@@ -506,6 +507,14 @@ void SavedSublist::setUnreadCount(std::optional<int> count) {
 	_unreadCount = count;
 	if (!count && !_readRequestTimer.isActive() && !_readRequestId) {
 		reloadUnreadCountIfNeeded();
+		
+		// Reset soft mute counter when user reads all messages in saved sublist
+		const auto peerId = sublistPeer()->id.value;
+		auto softMute = EnhancedSettings::GetSoftMuteState(peerId);
+		if (softMute.enabled && softMute.lastNotificationTime != 0) {
+			// Reset to 0 so next message will trigger notification
+			EnhancedSettings::UpdateSoftMuteLastNotification(peerId, 0);
+		}
 	}
 }
 

--- a/Telegram/SourceFiles/data/filters/message_filter.h
+++ b/Telegram/SourceFiles/data/filters/message_filter.h
@@ -1,0 +1,40 @@
+/*
+This file is part of 64Gram Desktop,
+the unofficial app based on Telegram Desktop.
+For license and copyright information please follow this link:
+https://github.com/TDesktop-x64/tdesktop/blob/dev/LEGAL
+*/
+#pragma once
+
+#include <QtCore/QString>
+#include <QtCore/QSet>
+#include <QtCore/QRegularExpression>
+
+namespace MessageFilters {
+
+enum class FilterMode {
+	Whitelist,
+	Blacklist,
+	Replace
+};
+
+enum class FilterDisplayMode {
+	Hide,
+	Dim
+};
+
+struct MessageFilter {
+	QString id;
+	QString name;
+	QString regex;
+	QString replacementText; // Text to replace matches with (for Replace mode)
+	QSet<int64> userIds;
+	QSet<int64> chatIds; // empty = global
+	FilterMode mode;
+	FilterDisplayMode displayMode;
+	int order;
+	bool enabled;
+};
+
+} // namespace MessageFilters
+

--- a/Telegram/SourceFiles/data/filters/message_filter_matcher.cpp
+++ b/Telegram/SourceFiles/data/filters/message_filter_matcher.cpp
@@ -1,0 +1,121 @@
+/*
+This file is part of 64Gram Desktop,
+the unofficial app based on Telegram Desktop.
+For license and copyright information please follow this link:
+https://github.com/TDesktop-x64/tdesktop/blob/dev/LEGAL
+*/
+#include "data/filters/message_filter_matcher.h"
+
+#include "history/history_item.h"
+#include "history/history.h"
+#include "data/data_peer.h"
+#include "data/data_user.h"
+#include "core/enhanced_settings.h"
+#include "core/application.h"
+#include "main/main_session.h"
+
+#include <QtCore/QRegularExpression>
+
+namespace MessageFilters {
+
+FilterResult CheckMessageAgainstFilters(not_null<HistoryItem*> item) {
+	const auto filters = EnhancedSettings::GetMessageFilters();
+	
+	if (filters.isEmpty()) {
+		return { false, FilterDisplayMode::Hide, QString(), false };
+	}
+	
+	// Sort by order (only if needed)
+	auto sortedFilters = filters;
+	std::sort(sortedFilters.begin(), sortedFilters.end(), [](const auto &a, const auto &b) {
+		return a.order < b.order;
+	});
+
+	const auto chatId = item->history()->peer->id.value;
+
+	for (const auto &filter : sortedFilters) {
+		if (!filter.enabled) {
+			continue;
+		}
+
+		// Check if chat matches (if filter specifies chats)
+		if (!filter.chatIds.isEmpty() && !filter.chatIds.contains(chatId)) {
+			continue;
+		}
+
+		// Now check all conditions that must match (AND logic)
+		bool userMatches = true;
+		bool regexMatches = true;
+
+		// Check if user ID matches (if filter specifies user IDs)
+		if (!filter.userIds.isEmpty()) {
+			userMatches = false; // Default to false if userIds are specified
+			const auto from = item->from();
+			if (from) {
+				const auto userId = from->id.value;
+				if (filter.userIds.contains(userId)) {
+					userMatches = true;
+				}
+			}
+		}
+
+		// Check if text matches regex (if filter specifies regex)
+		QString replacedText;
+		if (!filter.regex.isEmpty()) {
+			regexMatches = false;
+			const auto text = item->originalText().text;
+			QRegularExpression regex(filter.regex);
+			if (regex.isValid()) {
+				const auto match = regex.match(text);
+				if (match.hasMatch()) {
+					regexMatches = true;
+					if (filter.mode == FilterMode::Replace) {
+						replacedText = text;
+						replacedText.replace(regex, filter.replacementText);
+					}
+				}
+			}
+		}
+
+		// All specified conditions must match (AND logic)
+		const bool matches = userMatches && regexMatches;
+
+		// Apply filter based on mode
+		if (matches) {
+			if (filter.mode == FilterMode::Blacklist) {
+				return { true, filter.displayMode, QString(), false };
+			} else if (filter.mode == FilterMode::Replace) {
+				return { false, FilterDisplayMode::Hide, replacedText, true };
+			} else {
+				// Whitelist: show this message
+				return { false, FilterDisplayMode::Hide, QString(), false };
+			}
+		} else if (filter.mode == FilterMode::Whitelist) {
+			// Whitelist: message doesn't match, hide it
+			return { true, FilterDisplayMode::Hide, QString(), false };
+		}
+	}
+
+	// No filters matched, show the message
+	return { false, FilterDisplayMode::Hide, QString(), false };
+}
+
+bool ShouldSuppressNotification(not_null<HistoryItem*> item) {
+	const auto result = CheckMessageAgainstFilters(item);
+	// Suppress notification if message is filtered by a blacklist
+	if (result.filtered) {
+		const auto filters = EnhancedSettings::GetMessageFilters();
+		for (const auto &filter : filters) {
+			if (!filter.enabled) continue;
+			
+			// Quick check if this could be the filter that matched
+			if (filter.mode == FilterMode::Blacklist) {
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
+} // namespace MessageFilters
+

--- a/Telegram/SourceFiles/data/filters/message_filter_matcher.h
+++ b/Telegram/SourceFiles/data/filters/message_filter_matcher.h
@@ -1,0 +1,30 @@
+/*
+This file is part of 64Gram Desktop,
+the unofficial app based on Telegram Desktop.
+For license and copyright information please follow this link:
+https://github.com/TDesktop-x64/tdesktop/blob/dev/LEGAL
+*/
+#pragma once
+
+#include "data/filters/message_filter.h"
+#include "base/basic_types.h"
+
+class HistoryItem;
+
+namespace MessageFilters {
+
+struct FilterResult {
+	bool filtered = false;
+	FilterDisplayMode displayMode = FilterDisplayMode::Hide;
+	QString replacedText; // For Replace mode: the text with replacements applied
+	bool isReplaced = false; // True if Replace mode was applied
+};
+
+[[nodiscard]] FilterResult CheckMessageAgainstFilters(
+	not_null<HistoryItem*> item);
+
+[[nodiscard]] bool ShouldSuppressNotification(
+	not_null<HistoryItem*> item);
+
+} // namespace MessageFilters
+

--- a/Telegram/SourceFiles/history/view/history_view_element.cpp
+++ b/Telegram/SourceFiles/history/view/history_view_element.cpp
@@ -24,6 +24,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "history/history.h"
 #include "history/history_item_components.h"
 #include "history/history_item_helpers.h"
+#include "data/filters/message_filter_matcher.h"
 #include "base/unixtime.h"
 #include "boxes/premium_preview_box.h"
 #include "core/application.h"
@@ -1049,7 +1050,17 @@ bool Element::isHiddenByGroup() const {
 }
 
 bool Element::isHidden() const {
-	return isHiddenByGroup();
+	if (isHiddenByGroup()) {
+		return true;
+	}
+	
+	// Check message filters
+	const auto filterResult = MessageFilters::CheckMessageAgainstFilters(data());
+	if (filterResult.filtered && filterResult.displayMode == MessageFilters::FilterDisplayMode::Hide) {
+		return true;
+	}
+	
+	return false;
 }
 
 void Element::overrideMedia(std::unique_ptr<Media> media) {

--- a/Telegram/SourceFiles/menu/menu_mute.h
+++ b/Telegram/SourceFiles/menu/menu_mute.h
@@ -35,6 +35,7 @@ struct Descriptor {
 	Fn<void(Data::NotifySound)> updateSound;
 	Fn<void(TimeId)> updateMutePeriod;
 	Data::VolumeController volumeController;
+	Data::Thread *thread = nullptr; // Optional, for soft mute support
 };
 
 [[nodiscard]] Descriptor ThreadDescriptor(not_null<Data::Thread*> thread);

--- a/Telegram/SourceFiles/settings/settings_enhanced.h
+++ b/Telegram/SourceFiles/settings/settings_enhanced.h
@@ -25,12 +25,12 @@ namespace Settings {
 		[[nodiscard]] rpl::producer<QString> title() override;
 
 	private:
-		void setupContent(not_null<Window::SessionController *> controller);
-		void SetupEnhancedNetwork(not_null<Ui::VerticalLayout *> container);
-		void SetupEnhancedMessages(not_null<Ui::VerticalLayout *> container);
-		void SetupEnhancedButton(not_null<Ui::VerticalLayout *> container);
-		void SetupEnhancedVoiceChat(not_null<Ui::VerticalLayout *> container);
-		void SetupEnhancedOthers(not_null<Window::SessionController*> controller, not_null<Ui::VerticalLayout *> container);
+	void setupContent(not_null<Window::SessionController *> controller);
+	void SetupEnhancedNetwork(not_null<Ui::VerticalLayout *> container);
+	void SetupEnhancedMessages(not_null<Window::SessionController*> controller, not_null<Ui::VerticalLayout *> container);
+	void SetupEnhancedButton(not_null<Ui::VerticalLayout *> container);
+	void SetupEnhancedVoiceChat(not_null<Ui::VerticalLayout *> container);
+	void SetupEnhancedOthers(not_null<Window::SessionController*> controller, not_null<Ui::VerticalLayout *> container);
 		void reqBlocked(int offset);
 		void writeBlocklistFile();
 


### PR DESCRIPTION
Similar to mute notifications for any chat, this feature, when activated, can limit message notifications for selected chat to no more than one in specified time period. So, if a chat is set as soft mute within 5 minutes and user isn't focusing on this chat, after the first notification of this chat, user won't be getting more notifications from that chat (configurable as send without sound or completely hidden), until 5 minutes have passed or user have focus on the chat, and then it starts the new cycle.