### PR TITLE
Add batch "Dismiss all" and "Ban all" actions to join requests UI

### DIFF
--- a/Telegram/Resources/langs/lang.strings
+++ b/Telegram/Resources/langs/lang.strings
@@ -2618,6 +2618,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 "lng_group_requests_none_channel" = "There are no pending join requests.";
 "lng_group_requests_dismiss_all_confirm" = "Are you sure you want to dismiss all pending join requests?";
 "lng_group_requests_ban_all_confirm" = "Are you sure you want to ban all users who requested to join?";
+"lng_group_requests_ban_too_much_users" = "You cannot ban so many users at once. Try dismissing them instead.";
 
 "lng_channel_public_link_copied" = "Link copied to clipboard.";
 "lng_context_about_private_link" = "This link will only work for members of this chat.";

--- a/Telegram/Resources/langs/lang.strings
+++ b/Telegram/Resources/langs/lang.strings
@@ -2610,10 +2610,14 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 "lng_group_requests_add" = "Add to Group";
 "lng_group_requests_add_channel" = "Add to Channel";
 "lng_group_requests_dismiss" = "Dismiss";
+"lng_group_requests_dismiss_all" = "Dismiss all";
+"lng_group_requests_ban_all" = "Ban all";
 "lng_group_requests_was_added" = "{user} has been added to the group.";
 "lng_group_requests_was_added_channel" = "{user} has been added to the channel.";
 "lng_group_requests_none" = "There are no pending join requests.";
 "lng_group_requests_none_channel" = "There are no pending join requests.";
+"lng_group_requests_dismiss_all_confirm" = "Are you sure you want to dismiss all pending join requests?";
+"lng_group_requests_ban_all_confirm" = "Are you sure you want to ban all users who requested to join?";
 
 "lng_channel_public_link_copied" = "Link copied to clipboard.";
 "lng_context_about_private_link" = "This link will only work for members of this chat.";

--- a/Telegram/SourceFiles/boxes/boxes.style
+++ b/Telegram/SourceFiles/boxes/boxes.style
@@ -1026,11 +1026,16 @@ requestsRejectButton: RoundButton(defaultLightButton) {
 	textTop: 6px;
 }
 requestsBanButton: RoundButton(defaultActiveButton) {
+    textBg: banButtonBg;
+	textBgOver: banButtonBgOver;
 	width: -28px;
 	height: 30px;
 	textTop: 6px;
+	ripple: RippleAnimation(defaultRippleAnimation) {
+        color: banButtonBgRipple;
+    }
 }
-requestsBanAllButton: RoundButton(defaultActiveButton) {
+requestsBanAllButton: RoundButton(requestsBanButton) {
 	width: -28px;
 	height: 30px;
 	textTop: 6px;

--- a/Telegram/SourceFiles/boxes/boxes.style
+++ b/Telegram/SourceFiles/boxes/boxes.style
@@ -1030,6 +1030,11 @@ requestsBanButton: RoundButton(defaultActiveButton) {
 	height: 30px;
 	textTop: 6px;
 }
+requestsBanAllButton: RoundButton(defaultActiveButton) {
+	width: -28px;
+	height: 30px;
+	textTop: 6px;
+}
 requestAcceptPosition: point(71px, 58px);
 requestButtonsSkip: 9px;
 

--- a/Telegram/SourceFiles/boxes/peers/edit_peer_requests_box.cpp
+++ b/Telegram/SourceFiles/boxes/peers/edit_peer_requests_box.cpp
@@ -32,6 +32,8 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "ui/painter.h"
 #include "ui/round_rect.h"
 #include "ui/text/text_utilities.h"
+#include "ui/widgets/buttons.h"
+#include "ui/boxes/confirm_box.h"
 #include "window/window_session_controller.h"
 #include "styles/style_boxes.h"
 
@@ -398,7 +400,113 @@ void RequestsBoxController::prepare() {
 		: tr::lng_manage_peer_requests());
 	setDescriptionText(tr::lng_contacts_loading(tr::now));
 	setSearchNoResultsText(tr::lng_blocked_list_not_found(tr::now));
+	delegate()->peerListSetAboveWidget(createBatchActionsWidget());
 	loadMoreRows();
+}
+
+object_ptr<Ui::RpWidget> RequestsBoxController::createBatchActionsWidget() {
+	auto result = object_ptr<Ui::RpWidget>((QWidget*)nullptr);
+	const auto container = result.data();
+
+	const auto dismissAll = Ui::CreateChild<Ui::RoundButton>(
+		container,
+		tr::lng_group_requests_dismiss_all(),
+		st::requestsRejectButton);
+	dismissAll->setTextTransform(Ui::RoundButton::TextTransform::NoTransform);
+	dismissAll->setClickedCallback([=] {
+		dismissAllRequests();
+	});
+
+	const auto banAll = Ui::CreateChild<Ui::RoundButton>(
+		container,
+		tr::lng_group_requests_ban_all(),
+		st::requestsBanAllButton);
+	banAll->setTextTransform(Ui::RoundButton::TextTransform::NoTransform);
+	banAll->setClickedCallback([=] {
+		banAllRequests();
+	});
+
+	container->widthValue(
+	) | rpl::start_with_next([=](int width) {
+		const auto padding = st::requestButtonsSkip * 2;
+		const auto buttonWidth = (width - padding * 3) / 2;
+		const auto height = st::requestsAcceptButton.height + st::requestButtonsSkip * 2;
+		container->resize(width, height);
+		dismissAll->setGeometry(
+			padding,
+			st::requestButtonsSkip,
+			buttonWidth,
+			st::requestsAcceptButton.height);
+		banAll->setGeometry(
+			padding * 2 + buttonWidth,
+			st::requestButtonsSkip,
+			buttonWidth,
+			st::requestsAcceptButton.height);
+	}, container->lifetime());
+
+	return result;
+}
+
+void RequestsBoxController::dismissAllRequests() {
+	const auto count = delegate()->peerListFullRowsCount();
+	if (count == 0) {
+		return;
+	}
+
+	const auto guard = base::make_weak(this);
+	delegate()->peerListUiShow()->showBox(Ui::MakeConfirmBox({
+		.text = tr::lng_group_requests_dismiss_all_confirm(tr::now),
+		.confirmed = [=] {
+			if (!guard) {
+				return;
+			}
+			// Collect all users
+			std::vector<not_null<UserData*>> users;
+			const auto fullCount = delegate()->peerListFullRowsCount();
+			for (auto i = 0; i < fullCount; ++i) {
+				const auto row = delegate()->peerListRowAt(i);
+				if (const auto user = row->peer()->asUser()) {
+					users.push_back(user);
+				}
+			}
+
+			// Process all requests
+			for (const auto user : users) {
+				processRequest(user, false, false);
+			}
+		}
+	}));
+}
+
+void RequestsBoxController::banAllRequests() {
+	const auto count = delegate()->peerListFullRowsCount();
+	if (count == 0) {
+		return;
+	}
+
+	const auto guard = base::make_weak(this);
+	delegate()->peerListUiShow()->showBox(Ui::MakeConfirmBox({
+		.text = tr::lng_group_requests_ban_all_confirm(tr::now),
+		.confirmed = [=] {
+			if (!guard) {
+				return;
+			}
+			// Collect all users
+			std::vector<not_null<UserData*>> users;
+			const auto fullCount = delegate()->peerListFullRowsCount();
+			for (auto i = 0; i < fullCount; ++i) {
+				const auto row = delegate()->peerListRowAt(i);
+				if (const auto user = row->peer()->asUser()) {
+					users.push_back(user);
+				}
+			}
+
+			// Process all requests
+			for (const auto user : users) {
+				processRequest(user, false, true);
+			}
+		}
+	}));
 }
 
 void RequestsBoxController::loadMoreRows() {

--- a/Telegram/SourceFiles/boxes/peers/edit_peer_requests_box.cpp
+++ b/Telegram/SourceFiles/boxes/peers/edit_peer_requests_box.cpp
@@ -484,6 +484,14 @@ void RequestsBoxController::banAllRequests() {
 		return;
 	}
 
+	if (count >= 20) {
+		delegate()->peerListUiShow()->showBox(Ui::MakeConfirmBox({
+			.text = tr::lng_group_requests_ban_too_much_users(tr::now),
+			.inform = true
+		}));
+		return;
+	}
+
 	const auto guard = base::make_weak(this);
 	delegate()->peerListUiShow()->showBox(Ui::MakeConfirmBox({
 		.text = tr::lng_group_requests_ban_all_confirm(tr::now),

--- a/Telegram/SourceFiles/boxes/peers/edit_peer_requests_box.cpp
+++ b/Telegram/SourceFiles/boxes/peers/edit_peer_requests_box.cpp
@@ -405,7 +405,7 @@ void RequestsBoxController::prepare() {
 }
 
 object_ptr<Ui::RpWidget> RequestsBoxController::createBatchActionsWidget() {
-	auto result = object_ptr<Ui::RpWidget>((QWidget*)nullptr);
+	auto result = object_ptr<Ui::RpWidget>(static_cast<QWidget*>(nullptr));
 	const auto container = result.data();
 
 	const auto dismissAll = Ui::CreateChild<Ui::RoundButton>(
@@ -697,7 +697,6 @@ void RequestsBoxController::RowHelper::rowPaintBan(
 		std::unique_ptr<Ui::RippleAnimation> &ripple,
 		int outerWidth,
 		bool over) {
-	_banRect.setColor(st::banButtonBg);
 	paintButton(
 		p,
 		geometry,

--- a/Telegram/SourceFiles/boxes/peers/edit_peer_requests_box.h
+++ b/Telegram/SourceFiles/boxes/peers/edit_peer_requests_box.h
@@ -72,6 +72,10 @@ private:
 	void refreshDescription();
 	void processRequest(not_null<UserData*> user, bool approved, bool banned);
 
+	[[nodiscard]] object_ptr<Ui::RpWidget> createBatchActionsWidget();
+	void dismissAllRequests();
+	void banAllRequests();
+
 	void subscribeToMigration();
 	void migrate(not_null<ChatData*> chat, not_null<ChannelData*> channel);
 


### PR DESCRIPTION
Implement "Dismiss all" and "Ban all" actions for admin in join requests UI.
Hide buttons when search is applied.

Screenshots:
<img width="594" height="423" alt="image" src="https://github.com/user-attachments/assets/47db5e5b-fecf-40e9-96aa-80e8703d7a62" />
<img width="516" height="223" alt="image" src="https://github.com/user-attachments/assets/37e3f445-c9b1-43b8-9f78-de4470425502" />
<img width="615" height="531" alt="image" src="https://github.com/user-attachments/assets/0dcf4a9e-d427-42af-beaf-2647c0d31187" />

