### PR TITLE
Add Alt+Shift+Up/Down to cycle through your editable messages

### DIFF
--- a/Telegram/SourceFiles/history/history_widget.cpp
+++ b/Telegram/SourceFiles/history/history_widget.cpp
@@ -74,6 +74,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "data/notify/data_notify_settings.h"
 #include "data/data_changes.h"
 #include "data/data_drafts.h"
+#include "data/data_groups.h"
 #include "data/data_session.h"
 #include "data/data_todo_list.h"
 #include "data/data_web_page.h"
@@ -223,6 +224,12 @@ constexpr auto kCommonModifiers = 0
 	| Qt::ShiftModifier
 	| Qt::MetaModifier
 	| Qt::ControlModifier;
+
+[[nodiscard]] bool IsEditCycleModifiers(Qt::KeyboardModifiers modifiers) {
+	return (modifiers & (kCommonModifiers | Qt::AltModifier))
+		== (Qt::AltModifier | Qt::ShiftModifier);
+}
+
 const auto kPsaAboutPrefix = "cloud_lng_about_psa_";
 
 [[nodiscard]] rpl::producer<PeerData*> ActivePeerValue(
@@ -5857,6 +5864,12 @@ bool HistoryWidget::eventFilter(QObject *obj, QEvent *e) {
 #endif
 				return replyToNextMessage();
 			}
+		} else if (IsEditCycleModifiers(k->modifiers())) {
+			if (k->key() == Qt::Key_Up) {
+				return editPreviousMessage();
+			} else if (k->key() == Qt::Key_Down) {
+				return editNextMessage();
+			}
 		}
 	}
 	return RpWidget::eventFilter(obj, e);
@@ -8119,6 +8132,16 @@ void HistoryWidget::keyPressEvent(QKeyEvent *e) {
 		if (!replyToNextMessage()) {
 			e->ignore();
 		}
+	} else if (e->key() == Qt::Key_Up
+		&& IsEditCycleModifiers(e->modifiers())) {
+		if (!editPreviousMessage()) {
+			e->ignore();
+		}
+	} else if (e->key() == Qt::Key_Down
+		&& IsEditCycleModifiers(e->modifiers())) {
+		if (!editNextMessage()) {
+			e->ignore();
+		}
 	} else if (e->key() == Qt::Key_Return || e->key() == Qt::Key_Enter) {
 		if (!_botStart->isHidden()) {
 			sendBotStartCommand();
@@ -8247,6 +8270,87 @@ bool HistoryWidget::replyToNextMessage() {
 		}
 	}
 	return false;
+}
+
+bool HistoryWidget::editPreviousMessage() {
+	if (!_history) {
+		return false;
+	}
+	const auto target = [&]() -> HistoryItem* {
+		if (!_editMsgId || !_replyEditMsg) {
+			return _history->lastEditableMessage();
+		}
+		const auto view = _replyEditMsg->mainView();
+		if (!view) {
+			return nullptr;
+		}
+		const auto now = base::unixtime::now();
+		auto previous = view->previousDisplayedInBlocks();
+		while (previous && !previous->data()->allowsEdit(now)) {
+			previous = previous->previousDisplayedInBlocks();
+		}
+		if (!previous) {
+			return nullptr;
+		}
+		return session().data().groups().findItemToEdit(previous->data());
+	}();
+	if (!target) {
+		return false;
+	}
+	const auto id = target->fullId();
+	confirmDiscardEdit(crl::guard(this, [=] {
+		if (const auto item = session().data().message(id)) {
+			editMessage(item, {});
+		}
+	}));
+	return true;
+}
+
+bool HistoryWidget::editNextMessage() {
+	if (!_history || !_editMsgId || !_replyEditMsg) {
+		return false;
+	}
+	const auto view = _replyEditMsg->mainView();
+	if (!view) {
+		return false;
+	}
+	const auto now = base::unixtime::now();
+	auto next = view->nextDisplayedInBlocks();
+	while (next && !next->data()->allowsEdit(now)) {
+		next = next->nextDisplayedInBlocks();
+	}
+	if (next) {
+		const auto id = session().data().groups().findItemToEdit(
+			next->data())->fullId();
+		confirmDiscardEdit(crl::guard(this, [=] {
+			if (const auto item = session().data().message(id)) {
+				editMessage(item, {});
+			}
+		}));
+	} else {
+		confirmDiscardEdit(crl::guard(this, [=] {
+			cancelEdit();
+		}));
+	}
+	return true;
+}
+
+void HistoryWidget::confirmDiscardEdit(Fn<void()> proceed) {
+	if (_editMsgId
+		&& _replyEditMsg
+		&& EditTextChanged(_replyEditMsg, _field->getTextWithTags())) {
+		controller()->show(Ui::MakeConfirmBox({
+			.text = tr::lng_cancel_edit_post_sure(),
+			.confirmed = crl::guard(this, [=](Fn<void()> &&close) {
+				proceed();
+				close();
+			}),
+			.confirmText = tr::lng_cancel_edit_post_yes(),
+			.cancelText = tr::lng_cancel_edit_post_no(),
+		}));
+	} else {
+		proceed();
+	}
 }
 
 bool HistoryWidget::showSlowmodeError() {

--- a/Telegram/SourceFiles/history/history_widget.h
+++ b/Telegram/SourceFiles/history/history_widget.h
@@ -570,6 +570,9 @@ private:
 	void cancelReplyAfterMediaSend(bool lastKeyboardUsed);
 	bool replyToPreviousMessage();
 	bool replyToNextMessage();
+	bool editPreviousMessage();
+	bool editNextMessage();
+	void confirmDiscardEdit(Fn<void()> proceed);
 	[[nodiscard]] bool showSlowmodeError();
 
 	void hideChildWidgets();


### PR DESCRIPTION
## What

- **Alt+Shift+Up** — edit your most recent editable message; each further press steps to the next older one (stops at the oldest).
- **Alt+Shift+Down** — step to the next newer editable message; past your newest, exit edit mode.
- Jumping away from an in-progress edit with unsaved changes shows the existing "Cancel editing?" confirmation.

## Why

Requested by a keyboard-only user: the Up arrow already edits the last message and Ctrl+Up/Down cycles reply targets, but there was no way to walk through your own messages to edit them.

## Notes

- Implemented in `HistoryWidget` alongside the existing Ctrl+Up/Down reply-cycling; reuses `History::lastEditableMessage` and the displayed-message traversal, so grouped/album messages resolve through `findItemToEdit` like the existing edit path.
- `Ctrl+Shift+Up/Down` (the natural sibling chord) was avoided because it's already bound to folder navigation; `Alt+Shift+Up/Down` is unbound.
- Scope: main chat (`HistoryWidget`) only. The `ComposeControls` surfaces (topics/threads/scheduled) are untouched and could be a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
